### PR TITLE
Atualização da Versão do Kong para Captura de Métricas no Grafana

### DIFF
--- a/compose/kong_compose.yml
+++ b/compose/kong_compose.yml
@@ -1,4 +1,4 @@
-# version: "3.7"
+version: "3.7"
 
 networks:
   kong-fc:

--- a/compose/kong_compose.yml
+++ b/compose/kong_compose.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+# version: "3.7"
 
 networks:
   kong-fc:
@@ -38,7 +38,9 @@ services:
   ### armazenamento das configuracoes do Kong
   ###
   kong-migration-bootstrap:
-    image: claudioed/kong-fc
+    build:
+      context: ../docker
+      dockerfile: Dockerfile
     deploy:
       restart_policy:
         condition: on-failure
@@ -59,7 +61,9 @@ services:
   ### armazenamento das configuracoes do Kong
   ###
   kong-migration-up:
-    image: claudioed/kong-fc
+    build:
+      context: ../docker
+      dockerfile: Dockerfile
     networks:
       - kong-fc
     deploy:
@@ -80,7 +84,9 @@ services:
   ###
   kong:
     container_name: kong
-    image: claudioed/kong-fc
+    build:
+      context: ../docker
+      dockerfile: Dockerfile
     networks:
       - kong-fc
     deploy:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,8 @@
-FROM kong:2.8.1-alpine
+FROM kong:3.0.2-alpine
 
 USER root
-RUN luarocks install kong-oidc && \
+RUN apk add git && \
+    luarocks install kong-oidc && \
     luarocks install kong-jwt2header && \
     luarocks install kong-upstream-jwt
 


### PR DESCRIPTION
###  O que isso resolve?

@claudioed @vitormalencar @carlosfgti @wilsonneto-dev 

Este pull request corrige um problema específico relacionado à aula de **API Gateway**. Alguns alunos estavam enfrentando dificuldades com a exibição de métricas no **Grafana** devido à versão **2.8.1** do Kong utilizada na imagem `"claudioed/kong-fc"`. 

Essa versão não suporta as métricas **`status_code_metrics`** e **`latency_metrics`**, impedindo a captura adequada dos dados. 

O problema foi relatado neste tópico do fórum FC:  
🔗 [API Gateway - Dashboard Request Rate do Kong não exibe dados no Grafana](https://forum.code.education/forum/topico/api-gateway-dashboard-request-rate-do-kong-nao-exibe-dados-no-grafana-2076/)

Para evitar que futuros alunos enfrentem essa mesma dificuldade, estou abrindo esse PR propondo essa atualização da versão do Kong.

---

### Alterações realizadas

- **Modificação do `Dockerfile`**  para utilizar a imagem `kong:3.0.2-alpine` 
- **Atualização do `kong-compose.yml`** para refletir essa atualização

---

### Impacto nos containers

Os seguintes containers são afetados por essa mudança:

- `kong`
- `kong-migration-bootstrap`
- `kong-migration-up`


###  Possíveis problemas ao testar

1. **Problemas de migração**  
   Se houver erros na migração do banco de dados, pode ser necessário remover o volume do **PostgreSQL** para que tudo ocorra corretamente.

2. **Habilitação manual do Prometheus**  
   Caso as métricas ainda não estejam disponíveis, você pode ativá-las manualmente utilizando a API do Kong. Execute o seguinte comando, substituindo `<service-name>` pelo nome do serviço configurado no **Konga**:

```sh
   curl -X POST http://localhost:8001/services/<service-name>/plugins \
     --data "name=prometheus" \
     --data "config.status_code_metrics=true" \
     --data "config.latency_metrics=true"
 ```